### PR TITLE
Miscellaneous clean-ups

### DIFF
--- a/app/helper.cpp
+++ b/app/helper.cpp
@@ -164,7 +164,7 @@ void Helper::openFileDialog(FileDialogType dialogType,
         dlg.setNameFilter(getFilter(subtitleFilters));
         break;
     case FileDialogType::SELECTFOLDER:
-        dlg.setFileMode(QFileDialog::DirectoryOnly);
+        dlg.setOption(QFileDialog::ShowDirsOnly, true);
         break;
     }
     if (dlg.exec() == QFileDialog::Accepted) {

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -246,7 +246,7 @@ private slots:
     void onSortDown();
     void onSortUp();
     void setParameters();
-    void setDocksParameters(QList<int> dockSizesX, QList<int> dockSizesY);
+    void setDocksParameters(const QList<int>& dockSizesX, const QList<int>& dockSizesY);
 
     void showEvent(QShowEvent*);
     void closeEvent(QCloseEvent*);


### PR DESCRIPTION
Use auto where possible to avoid duplicating type.
Use empty() instead of size() comparison.
Remove unused headers
Avoid use of reserved identifiers.
Use parentheses in macros.
Address deprecation warnings for file and dock in Qt.
Use const references in a few places.
Simplified some expressions.

Build tested on Linux only.