### PR TITLE
Subtitle hard-burn contributions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Ignored folders:
 /builddir
+cmake-build-debug/
+.idea/
 
 # Ignored files:
 *.pro.user

--- a/app/constants.h
+++ b/app/constants.h
@@ -185,6 +185,7 @@ namespace Constants {
 
     struct EncoderSubtParam {
         int SUBT_CODEC;
+        bool burn;
         QString SUBT_CONTAINER;
     };
 

--- a/app/encoder.cpp
+++ b/app/encoder.cpp
@@ -314,8 +314,6 @@ void Encoder::initEncoding(const QString  &temp_file,
 
     Q_LOOP(k, 0, CHECKS(externSubtChecks).size()) {
         if (CHECKS(externSubtChecks)[k] == true) {
-            _extSubPaths << "-i" << FIELDS(externSubtPath)[k];
-
             if (CHECKS(externSubtBurn)[k] == true) {
                 _burn_subtitle = true;
                 extSubBurn[k] = " -vf \"subtitles=" + FIELDS(externSubtPath)[k] + "\" ";
@@ -323,6 +321,7 @@ void Encoder::initEncoding(const QString  &temp_file,
                 _subtitleMetadataParam += " ";
             }
             else {
+                _extSubPaths << "-i" << FIELDS(externSubtPath)[k];
                 extSubMap[k] = QString("-map %1:s? ").arg(numToStr(extTrackNum));
                 extSubLang[k] = QString("-metadata:s:s:%1 language=%2 ")
                         .arg(numToStr(subtNum), FIELDS(externSubtLangs)[k].replace(" ", "\u00A0"));
@@ -943,7 +942,13 @@ void Encoder::encode()   // Encode
                       << _preset_pass1.split(" ");
         }
     }
-    //qDebug() << arguments;
+    // qDebug() << arguments;
+    std::string args_ = "";
+    for (int i = 0; i < arguments.count(); i++)
+    {
+        args_ += arguments[i].toStdString() + " ";
+    }
+    Print(args_);
     processEncoding->start("ffmpeg", arguments);
     if (!processEncoding->waitForStarted()) {
         Print("cmd command not found!!!");

--- a/app/encoder.cpp
+++ b/app/encoder.cpp
@@ -275,24 +275,33 @@ void Encoder::initEncoding(const QString  &temp_file,
     QVector<QString> subtitleLang(CHECKS(subtChecks).size(), ""),
                      subtitleTitle(CHECKS(subtChecks).size(), ""),
                      subtitleMap(CHECKS(subtChecks).size(), ""),
-                     subtitleDef(CHECKS(subtChecks).size(), "");
+                     subtitleDef(CHECKS(subtChecks).size(), ""),
+                     subtitleBurn(CHECKS(subtChecks).size(), "");
     QString _subtitleMapParam(""),
             _subtitleMetadataParam("");
     int     subtNum = 0;
 
     Q_LOOP(k, 0, CHECKS(subtChecks).size()) {
         if (CHECKS(subtChecks)[k] == true) {
-            subtitleMap[k] = QString("-map 0:s:%1? ").arg(numToStr(k));
-            subtitleLang[k] = QString("-metadata:s:s:%1 language=%2 ")
-                           .arg(numToStr(subtNum), FIELDS(subtLangs)[k].replace(" ", "\u00A0"));
-            subtitleTitle[k] = QString("-metadata:s:s:%1 title=%2 ")
-                            .arg(numToStr(subtNum), FIELDS(subtTitles)[k].replace(" ", "\u00A0"));
-            subtitleDef[k] = QString("-disposition:s:%1 %2 ")
-                           .arg(numToStr(subtNum), CHECKS(subtDef)[k] ? "default" : "0");
+            if (CHECKS(subtBurn)[k]) {
+                _burn_subtitle = true;
+                subtitleBurn[k] = " -vf \"subtitles=" + input_file + ":stream_index=" + numToStr(subtNum) + "\" ";
+                _subtitleMapParam += subtitleBurn[k];
+                _subtitleMetadataParam += " ";
+            }
+            else {
+                subtitleMap[k] = QString("-map 0:s:%1? ").arg(numToStr(k));
+                subtitleLang[k] = QString("-metadata:s:s:%1 language=%2 ")
+                        .arg(numToStr(subtNum), FIELDS(subtLangs)[k].replace(" ", "\u00A0"));
+                subtitleTitle[k] = QString("-metadata:s:s:%1 title=%2 ")
+                        .arg(numToStr(subtNum), FIELDS(subtTitles)[k].replace(" ", "\u00A0"));
+                subtitleDef[k] = QString("-disposition:s:%1 %2 ")
+                        .arg(numToStr(subtNum), CHECKS(subtDef)[k] ? "default" : "0");
+                _subtitleMapParam += subtitleMap[k];
+                _subtitleMetadataParam += subtitleLang[k] + subtitleTitle[k] + subtitleDef[k];
+            }
             subtNum++;
         }
-        _subtitleMapParam += subtitleMap[k];
-        _subtitleMetadataParam += subtitleLang[k] + subtitleTitle[k] + subtitleDef[k];
     }
 
     /****************************** External Subtitle streams *********************************/
@@ -300,23 +309,33 @@ void Encoder::initEncoding(const QString  &temp_file,
     QVector<QString> extSubLang(CHECKS(externSubtChecks).size(), ""),
                      extSubTitle(CHECKS(externSubtChecks).size(), ""),
                      extSubMap(CHECKS(externSubtChecks).size(), ""),
-                     extSubDef(CHECKS(externSubtChecks).size(), "");
+                     extSubDef(CHECKS(externSubtChecks).size(), ""),
+                     extSubBurn(CHECKS(externSubtChecks).size(), "");
 
     Q_LOOP(k, 0, CHECKS(externSubtChecks).size()) {
         if (CHECKS(externSubtChecks)[k] == true) {
             _extSubPaths << "-i" << FIELDS(externSubtPath)[k];
-            extSubMap[k] = QString("-map %1:s? ").arg(numToStr(extTrackNum));
-            extSubLang[k] = QString("-metadata:s:s:%1 language=%2 ")
-                           .arg(numToStr(subtNum), FIELDS(externSubtLangs)[k].replace(" ", "\u00A0"));
-            extSubTitle[k] = QString("-metadata:s:s:%1 title=%2 ")
-                            .arg(numToStr(subtNum), FIELDS(externSubtTitles)[k].replace(" ", "\u00A0"));
-            extSubDef[k] = QString("-disposition:s:%1 %2 ")
-                           .arg(numToStr(subtNum), CHECKS(externSubtDef)[k] ? "default" : "0");
+
+            if (CHECKS(externSubtBurn)[k] == true) {
+                _burn_subtitle = true;
+                extSubBurn[k] = " -vf \"subtitles=" + FIELDS(externSubtPath)[k] + "\" ";
+                _subtitleMapParam += extSubBurn[k];
+                _subtitleMetadataParam += " ";
+            }
+            else {
+                extSubMap[k] = QString("-map %1:s? ").arg(numToStr(extTrackNum));
+                extSubLang[k] = QString("-metadata:s:s:%1 language=%2 ")
+                        .arg(numToStr(subtNum), FIELDS(externSubtLangs)[k].replace(" ", "\u00A0"));
+                extSubTitle[k] = QString("-metadata:s:s:%1 title=%2 ")
+                        .arg(numToStr(subtNum), FIELDS(externSubtTitles)[k].replace(" ", "\u00A0"));
+                extSubDef[k] = QString("-disposition:s:%1 %2 ")
+                        .arg(numToStr(subtNum), CHECKS(externSubtDef)[k] ? "default" : "0");
+                _subtitleMapParam += extSubMap[k];
+                _subtitleMetadataParam += extSubLang[k] + extSubTitle[k] + extSubDef[k];
+            }
             subtNum++;
             extTrackNum++;
         }
-        _subtitleMapParam += extSubMap[k];
-        _subtitleMetadataParam += extSubLang[k] + extSubTitle[k] + extSubDef[k];
     }
 
     /************************************* Codec module ***************************************/
@@ -464,28 +483,25 @@ void Encoder::initEncoding(const QString  &temp_file,
     /************************************ Subtitle module *************************************/
 
     QString sub_param("");
-    if (container == "mkv") {
-        _sub_mux_param = QString("-c:s ass");
-    }
-    else
-    if (container == "webm") {
-        _sub_mux_param = QString("-c:s webvtt");
-    }
-    else
-    if (container == "mp4" || container == "mov") {
-        _sub_mux_param = QString("-c:s mov_text");
-    }
-    else {
-        _sub_mux_param = QString("-sn");
-        emit onEncodingError(tr("Container \'%1\' will be transcoded without subtitles.")
-                             .arg(container), true);
-    }
 
-    if (_flag_hdr) {
-        sub_param = QString(" -c:s ass");
-    }
-    else {
-        sub_param = QString(" ") + _sub_mux_param;
+    if (!_burn_subtitle) {
+        if (container == "mkv") {
+            _sub_mux_param = QString("-c:s ass");
+        } else if (container == "webm") {
+            _sub_mux_param = QString("-c:s webvtt");
+        } else if (container == "mp4" || container == "mov") {
+            _sub_mux_param = QString("-c:s mov_text");
+        } else {
+            _sub_mux_param = QString("-sn");
+            emit onEncodingError(tr("Container \'%1\' will be transcoded without subtitles.")
+                                         .arg(container), true);
+        }
+
+        if (_flag_hdr) {
+            sub_param = QString(" -c:s ass");
+        } else {
+            sub_param = QString(" ") + _sub_mux_param;
+        }
     }
 
     /************************************* Color module ***************************************/

--- a/app/encoder.h
+++ b/app/encoder.h
@@ -71,6 +71,7 @@ public:
 private:
     bool    _flag_two_pass,
             _flag_hdr,
+            _burn_subtitle,
             _mux_mode;
 
     int     *fr_count;

--- a/app/encoderstream.cpp
+++ b/app/encoderstream.cpp
@@ -135,33 +135,23 @@ void EncoderStream::initEncoding(StreamData *data,
     /************************************ Subtitle module *************************************/
     QString scodec("");
     {
-        const QString selected_scodec = t.arr_scodec_sep[SCODEC];
-        if (selected_scodec == "SubRip") {
-            scodec = QString("-c:s srt");
-        }
-        else
-        if (selected_scodec == "WebVTT") {
-            scodec = QString("-c:s webvtt");
-        }
-        else
-        if (selected_scodec == "SubStation Alpha") {
-            scodec = QString("-c:s ssa");
-        }
-        else
-        if (selected_scodec == "Advanced SSA") {
-            scodec = QString("-c:s ass");
-        }
-        else
-        if (selected_scodec == "Timed Text") {
-            scodec = QString("-c:s ttml");
-        }
-        else
-        if (selected_scodec == "MOV text") {
-            scodec = QString("-c:s mov_text");
-        }
-        else
-        if (selected_scodec == tr("Source")) {
-            scodec = "-c:s copy";
+        if (!sParam->burn) {
+            const QString selected_scodec = t.arr_scodec_sep[SCODEC];
+            if (selected_scodec == "SubRip") {
+                scodec = QString("-c:s srt");
+            } else if (selected_scodec == "WebVTT") {
+                scodec = QString("-c:s webvtt");
+            } else if (selected_scodec == "SubStation Alpha") {
+                scodec = QString("-c:s ssa");
+            } else if (selected_scodec == "Advanced SSA") {
+                scodec = QString("-c:s ass");
+            } else if (selected_scodec == "Timed Text") {
+                scodec = QString("-c:s ttml");
+            } else if (selected_scodec == "MOV text") {
+                scodec = QString("-c:s mov_text");
+            } else if (selected_scodec == tr("Source")) {
+                scodec = "-c:s copy";
+            }
         }
     }
     const QString sparam = "-an " + scodec;

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1869,6 +1869,7 @@ void MainWindow::openFiles(const QStringList &openFileNames)    // Open files
                     _FIELDS(numRows, subtTitles).push_back(SINFO(size_t(j), "Title"));
                     const QString deflt = SINFO(size_t(j), "Default");
                     _CHECKS(numRows, subtDef).push_back(deflt == "Yes" ? true : false);
+                    _CHECKS(numRows, subtBurn).push_back(false);
                 } else {
                     break;
                 }
@@ -2220,6 +2221,7 @@ void MainWindow::onAddExtStream()
                                 _FIELDS(m_row, externSubtTitles).push_back(SINFO(0, "Title"));
                                 _FIELDS(m_row, externSubtPath).push_back(path);
                                 _CHECKS(m_row, externSubtDef).push_back(false);
+                                _CHECKS(m_row, externSubtBurn).push_back(false);
                             }
                         } else {
                             showInfoMessage(tr("File: \'%1\' is not subtitle file!").arg(path));

--- a/app/widgets/qstreamview.cpp
+++ b/app/widgets/qstreamview.cpp
@@ -137,6 +137,7 @@ void QStreamView::setList(Data &data)
     m_pLayout->addWidget(hw);
 
     if (m_type == Content::Audio) {
+        bool stub = false;
         for (int i = 0; i < FIELDS(audioFormats).size(); i++) {
             QWidget *cell = createCell(CHECKS(audioChecks)[i],
                                        FIELDS(audioFormats)[i],
@@ -146,7 +147,8 @@ void QStreamView::setList(Data &data)
                                        FIELDS(audioChannels)[i],
                                        FIELDS(audioChLayouts)[i],
                                        "",
-                                       CHECKS(audioDef)[i]);
+                                       CHECKS(audioDef)[i],
+                                       stub);
             m_pLayout->addWidget(cell);
         }
         for (int i = 0; i < FIELDS(externAudioFormats).size(); i++) {
@@ -159,6 +161,7 @@ void QStreamView::setList(Data &data)
                                        FIELDS(externAudioChLayouts)[i],
                                        FIELDS(externAudioPath)[i],
                                        CHECKS(externAudioDef)[i],
+                                       stub,
                                        true);
             m_pLayout->addWidget(cell);
         }
@@ -173,7 +176,8 @@ void QStreamView::setList(Data &data)
                                        "",
                                        "",
                                        "",
-                                       CHECKS(subtDef)[i]);
+                                       CHECKS(subtDef)[i],
+                                       CHECKS(subtBurn)[i]);
             m_pLayout->addWidget(cell);
         }
         for (int i = 0; i < FIELDS(externSubtFormats).size(); i++) {
@@ -186,6 +190,7 @@ void QStreamView::setList(Data &data)
                                        "",
                                        FIELDS(externSubtPath)[i],
                                        CHECKS(externSubtDef)[i],
+                                       CHECKS(externSubtBurn)[i],
                                        true);
             m_pLayout->addWidget(cell);
         }
@@ -349,7 +354,9 @@ QWidget *QStreamView::createCell(bool &state,
                                  QString chLayouts,
                                  const QString &path,
                                  bool &deflt,
-                                 bool externFlag)
+                                 bool &burn,
+                                 bool externFlag
+                                 )
 {
     auto connectAction = [this](QLineEdit* line, bool isVisible)->void {
         auto actionList = line->findChildren<QAction*>();
@@ -382,7 +389,7 @@ QWidget *QStreamView::createCell(bool &state,
     cell->setLayout(lut);
 
     // Radio button 'Default stream'
-    QRadioButton *rbtn = QStreamViewPrivate::createRadio(cell, "defaultStream", "", deflt);
+    QRadioButton *rbtn = QStreamViewPrivate::createRadio(cell, "defaultStream", "Default", deflt);
     rbtn->setFixedSize(QSize(12,12) * Helper::scaling());
     rbtn->setToolTip(tr("Default"));
     connect(rbtn, &QRadioButton::clicked, this, [this, cell, &deflt, &state](bool checked) {
@@ -456,11 +463,11 @@ QWidget *QStreamView::createCell(bool &state,
         infoLut->addWidget(labCh, 0, 1);
     } else
     if (m_type == Content::Subtitle) {
-        QRadioButton *brn_rbtn = QStreamViewPrivate::createRadio(info, "burnInto", tr("Burn into video"), false);
+        QRadioButton *brn_rbtn = QStreamViewPrivate::createRadio(info, "burnInto", "Burn", burn);
         brn_rbtn->setFixedHeight(12 * Helper::scaling());
-        connect(brn_rbtn, &QRadioButton::clicked, this, [this, cell, &deflt](bool checked) {
-            resetBurnFlags(m_pLayout->indexOf(cell));
-
+        connect(brn_rbtn, &QRadioButton::clicked, this, [this, cell, &burn](bool checked) {
+            //resetBurnFlags(m_pLayout->indexOf(cell));
+            burn = checked;
         });
         infoLut->addWidget(brn_rbtn, 0, 1, Qt::AlignLeft);
     }

--- a/app/widgets/qstreamview.h
+++ b/app/widgets/qstreamview.h
@@ -41,6 +41,7 @@ private:
                         QString chLayouts,
                         const QString &path,
                         bool &deflt,
+                        bool &burn,
                         bool externFlag = false);
     QVBoxLayout *m_pLayout;
     Content m_type;


### PR DESCRIPTION
This seems to get closer, but I get an error when trying to run through the GUI. The preset output looks fine for my test case :

`-map 0:v:0? -map 0:a:0?  -vf "subtitles=/home/phil/test/subtitles.srt" -map_metadata -1 -map_chapters -1 -map_metadata:s:v:0 -1 -metadata title=Here We Go -metadata:s:a:0 language= -metadata:s:a:0 title= -disposition:a:0 default  -pix_fmt yuv420p -c:v libx265 -profile:v main -preset fast -crf 25 -c:a aac -b:a 256k`


but the tool yields a failure.

Pasting this into a traditional ffmpeg commandline, it all looks fine and burns in the subtitles : 

`ffmpeg -i source.mp4 -map 0:v:0? -map 0:a:0?  -vf "subtitles=/home/phil/test/subtitles.srt" -map_metadata -1 -map_chapters -1 -map_metadata:s:v:0 -1 -metadata title=Here We Go -metadata:s:a:0 language= -metadata:s:a:0 title= -disposition:a:0 default  -pix_fmt yuv420p -c:v libx265 -profile:v main -preset fast -crf 25 -c:a aac -b:a 256k out.mp4`

so I'm not sure what's misfiring.

GUI was largely stabbing blindly, but I think it's OK. Anyway, I thought I'd send this over in case it helps, and hopefully doesn't hinder.

There's more to be done. Ideally, the use of hard-burn would be supported only on one subtitle entry. There's also likely some format restrictions to consider.