### PR TITLE
Restart refinement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Ignored folders:
 /builddir
 cmake-build-debug/
+cmake-build-release/
 .idea/
 
 # Ignored files:

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /builddir
 cmake-build-debug/
 cmake-build-release/
+cmake-build-relwithdebinfo/
 .idea/
 
 # Ignored files:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,9 @@ set(CMAKE_AUTORCC ON)
 include(GNUInstallDirs)
 set(CMAKE_AUTOUIC ON)
 
-find_package(QT NAMES Qt5 REQUIRED COMPONENTS Core)
+find_package(QT NAMES Qt6 REQUIRED COMPONENTS Core)
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED COMPONENTS Gui Multimedia Svg)
-find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Widgets X11Extras)
+find_package(Qt${QT_VERSION_MAJOR} OPTIONAL_COMPONENTS Widgets) # X11Extras)
 
 add_executable(cine_encoder WIN32 MACOSX_BUNDLE
     app/basedialog.cpp app/basedialog.h
@@ -81,7 +81,7 @@ endif()
 
 if(UNIX AND NOT MACOS)
     target_link_libraries(cine_encoder PRIVATE
-        Qt::X11Extras
+        # Qt::X11Extras
         X11
         Xext
         mediainfo

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ endif()
 if(UNIX AND NOT MACOS)
     target_link_libraries(cine_encoder PRIVATE
         # Qt::X11Extras
+	Qt::GuiPrivate
         X11
         Xext
         mediainfo

--- a/app/basedialog.cpp
+++ b/app/basedialog.cpp
@@ -77,7 +77,7 @@ void BaseDialog::changeEvent(QEvent *event)
     QDialog::changeEvent(event);
     if (event->type() == QEvent::WindowStateChange) {
         const int margin = windowState().testFlag(Qt::WindowMaximized) ? 0 : BORDER;
-        layout()->setMargin(margin);
+        layout()->setContentsMargins(margin, margin, margin, margin);
         QTimer::singleShot(50, this, [this]() {
             update();
         });

--- a/app/basedialog.cpp
+++ b/app/basedialog.cpp
@@ -114,15 +114,15 @@ bool BaseDialog::eventFilter(QObject *watched, QEvent *event)
         if ((event->type() == QEvent::MouseMove) && m_clickPressedFlag) {
             QMouseEvent* mouse_event = dynamic_cast<QMouseEvent*>(event);
             if (mouse_event->buttons() & Qt::LeftButton) {
-                if (isMaximized() && mouse_event->globalPos().y() > 80) {
+                if (isMaximized() && mouse_event->globalPosition().y() > 80) {
                     onExpandWindow();
                     QTimer::singleShot(50, this, [this, mouse_event](){
                         m_mouseClickCoordinate = QPoint(int(float(m_titlebar->width())/2), 30);
-                        this->move(mouse_event->globalPos() - m_mouseClickCoordinate);
+                        this->move(mouse_event->globalPosition().toPoint() - m_mouseClickCoordinate);
                     });
                 } else
                 if (!isMaximized()) {
-                    this->move(mouse_event->globalPos() - m_mouseClickCoordinate);
+                    this->move(mouse_event->globalPosition().toPoint() - m_mouseClickCoordinate);
                 }
                 return true;
             }
@@ -184,7 +184,7 @@ bool BaseDialog::eventFilter(QObject *watched, QEvent *event)
                     m_oldWidth = this->width();
                     m_oldHeight = this->height();
                     m_mouseClickCoordinate = mouse_event->pos();
-                    m_globalMouseClickCoordinate = mouse_event->globalPos();
+                    m_globalMouseClickCoordinate = mouse_event->globalPosition().toPoint();
                     const QPoint mouseClickCoordinate = mouse_event->pos();
                     if (mouseClickCoordinate.x() < BORDER) {
                         if (mouseClickCoordinate.y() < BORDER) {
@@ -231,8 +231,8 @@ bool BaseDialog::eventFilter(QObject *watched, QEvent *event)
                 if (mouse_event->buttons() & Qt::LeftButton) {
                     const int index = m_clickPressedToResizeFlag.indexOf(true);
                     if (index != -1) {
-                        const int deltaX = mouse_event->globalPos().x() - m_mouseClickCoordinate.x();
-                        const int deltaY = mouse_event->globalPos().y() - m_mouseClickCoordinate.y();
+                        const int deltaX = mouse_event->globalPosition().x() - m_mouseClickCoordinate.x();
+                        const int deltaY = mouse_event->globalPosition().y() - m_mouseClickCoordinate.y();
                         const int deltaWidth = deltaX - m_globalMouseClickCoordinate.x() + m_mouseClickCoordinate.x();
                         const int deltaHeight = deltaY - m_globalMouseClickCoordinate.y() + m_mouseClickCoordinate.y();
                         switch (index) {

--- a/app/encoder.cpp
+++ b/app/encoder.cpp
@@ -1159,7 +1159,7 @@ void Encoder::encode(int threads)   // Encode
     QStringList arguments;
     processEncoding->disconnect();
     connect(processEncoding, SIGNAL(readyReadStandardOutput()), this, SLOT(progress_1()));
-    connect(processEncoding, SIGNAL(finished(int)), this, SLOT(completed(int)));
+    connect(processEncoding, SIGNAL(finished(int)), this, SLOT(completed(int, int)));
     emit onEncodingProgress(0, 0.0f);
 
     // DEBUG

--- a/app/encoder.cpp
+++ b/app/encoder.cpp
@@ -117,7 +117,10 @@ void Encoder::initEncoding(const QString  &temp_file,
     QVector<double> extDurVect;
     foreach (auto dur, FIELDS(externAudioDuration))
         extDurVect.push_back(0.001*dur.toDouble());
-    double minExtTime = *std::min_element(std::begin(extDurVect), std::end(extDurVect));
+    double minExtTime = 0;
+    if (extDurVect.count() > 0) {
+        minExtTime = *std::min_element(extDurVect.begin(), extDurVect.end());
+    }
     Print("Min external time: " << minExtTime);
 
     QStringList _splitStartParam;

--- a/app/encoder.h
+++ b/app/encoder.h
@@ -57,7 +57,8 @@ public:
                       const QString  &subtitle_font_color,
                       const bool     burn_background,
                       const QString  &subtitle_background_color,
-                      int            subtitle_location
+                      int            subtitle_location,
+                      int threads
                       );
 
     QProcess::ProcessState getEncodingState();
@@ -102,11 +103,11 @@ private:
     QProcess *processEncoding;
 
 private slots:
-    void encode();
+    void encode(int threads);
     void add_metadata();
     void progress_1();
     void progress_2();
-    void completed(int);
+    void completed(int exit_code, int threads);
     void abort();
 
     void

--- a/app/encoder.h
+++ b/app/encoder.h
@@ -83,7 +83,8 @@ private:
             _burn_subtitle,
             _mux_mode;
 
-    int     *fr_count;
+    int     *fr_count,
+            _threads;
 
     time_t  _loop_start;
 
@@ -103,11 +104,11 @@ private:
     QProcess *processEncoding;
 
 private slots:
-    void encode(int threads);
+    void encode();
     void add_metadata();
     void progress_1();
     void progress_2();
-    void completed(int exit_code, int threads);
+    void completed(int exit_code);
     void abort();
 
     void

--- a/app/helper.cpp
+++ b/app/helper.cpp
@@ -1,7 +1,7 @@
 #include "helper.h"
 #include "constants.h"
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QLocale>
 #include <QFileDialog>
 #include <QFontMetrics>
@@ -164,7 +164,7 @@ void Helper::openFileDialog(FileDialogType dialogType,
         dlg.setNameFilter(getFilter(subtitleFilters));
         break;
     case FileDialogType::SELECTFOLDER:
-        dlg.setFileMode(QFileDialog::DirectoryOnly);
+        dlg.setOption(QFileDialog::ShowDirsOnly);
         break;
     }
     if (dlg.exec() == QFileDialog::Accepted) {
@@ -246,7 +246,8 @@ void Helper::nonBlockDelay(int msec)
 
 double Helper::scaling()
 {
-    double scale = double(qApp->desktop()->logicalDpiX()) / 96;
+    QScreen *scrn = QApplication::screens().at(0);
+    double scale = double(scrn->logicalDotsPerInchX()) / 96;
     return (scale < 1.25) ? 1.00 :
            (scale < 1.50) ? 1.25 :
            (scale < 1.75) ? 1.50 :

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -34,8 +34,6 @@ int main(int argc, char *argv[])
     qputenv("QT_LOGGING_RULES", "*.debug=false;qt.qpa.*=false");
 #endif
     QCoreApplication::setAttribute(Qt::AA_UseStyleSheetPropagationInWidgetStyles, true);
-    QCoreApplication::setAttribute(Qt::AA_UseHighDpiPixmaps, true);
-    QCoreApplication::setAttribute(Qt::AA_DisableHighDpiScaling, true);
     QCoreApplication::setOrganizationName(QString::fromUtf8("CineEncoder"));
     QCoreApplication::setApplicationName(QString::fromUtf8("Cine Encoder"));
     QApplication::setApplicationDisplayName("Cine Encoder");

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -22,7 +22,6 @@
 #include "report.h"
 #include "streamconverter.h"
 #include "fileiconprovider.h"
-#include <QDesktopWidget>
 #include <QDragEnterEvent>
 #include <QMimeDatabase>
 #include <QMimeData>
@@ -43,7 +42,6 @@
 #include <iomanip>
 #include <cmath>
 #include <sstream>
-
 
 #if defined (Q_OS_UNIX)
     #ifndef UNICODE
@@ -83,7 +81,6 @@
 
 typedef void(MainWindow::*FnVoidVoid)(void);
 typedef void(MainWindow::*FnVoidInt)(int);
-
 
 namespace MainWindowPrivate
 {
@@ -228,7 +225,10 @@ MainWindow::MainWindow(QWidget *parent):
         m_pDocks[i]->setObjectName(objNames[i]);
         m_pDocks[i]->setAllowedAreas(Qt::LeftDockWidgetArea | Qt::TopDockWidgetArea |
                                      Qt::RightDockWidgetArea | Qt::BottomDockWidgetArea);
-        m_pDocks[i]->setFeatures(QDockWidget::AllDockWidgetFeatures);
+        m_pDocks[i]->setFeatures(QDockWidget::DockWidgetClosable |
+                                 QDockWidget::DockWidgetMovable |
+                                 QDockWidget::DockWidgetFloatable
+                /*QDockWidget::DockWidgetVerticalTitleBar*/);
         m_pDocks[i]->setWidget(dockFrames[i]);
         m_pDocksContainer->addDockWidget(dockArea[i], m_pDocks[i]);
     }

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -1026,16 +1026,17 @@ void MainWindow::onSettings()
                            &m_subtitles_color,
                            &m_subtitles_background_color,
                            &m_subtitles_background_alpha,
-                           &m_subtitles_location
-                           );
+                           &m_subtitles_location);
     if (settings.exec() == Dialog::Accept) {
         m_pTimer->setInterval(m_timerInterval*1000);
         setTheme(m_theme);
         m_hideInTrayFlag ? m_pTrayIcon->show() : m_pTrayIcon->hide();
         if (m_row != -1)
             get_output_filename();
-        showPopup(tr("You need to restart the program for the settings to take effect."),
-                  PopupMessage::Icon::Warning);
+        if (settings.restart_needed) {
+            showPopup(tr("You need to restart the program for the settings to take effect."),
+                      PopupMessage::Icon::Warning);
+        }
     }
 }
 

--- a/app/mainwindow.cpp
+++ b/app/mainwindow.cpp
@@ -149,6 +149,7 @@ MainWindow::MainWindow(QWidget *parent):
     m_subtitles_background_color(QColor(DEFAULTSUBTITLEBACKGROUNDCOLOR)),
     m_subtitles_location(0),
     m_subtitles_background(0),
+    m_threads(0),
     m_windowActivated(false),
     m_expandWindowsState(false),
     m_rowHeight(ROWHEIGHTDFLT)
@@ -344,6 +345,7 @@ void MainWindow::closeEvent(QCloseEvent *event) // Show prompt when close app
         stn.setValue("Settings/subtitles_background_alpha", m_subtitles_background_alpha);
         stn.setValue("Settings/subtitles_background_color", m_subtitles_background_color.name());
         stn.setValue("Settings/subtitles_location", m_subtitles_location);
+        stn.setValue("Settings/threads", m_threads);
         stn.endGroup();
 
         if (m_pTrayIcon)
@@ -825,6 +827,7 @@ void MainWindow::setParameters()    // Set parameters
         m_subtitles_background_color = QColor(stn.value("Settings/subtitles_background_color", DEFAULTSUBTITLEBACKGROUNDCOLOR).toString());
         m_subtitles_background_alpha = stn.value("Settings/subtitles_background_alpha", 150).toInt();
         m_subtitles_location = stn.value("Settings/subtitles_location", 0).toInt();
+        m_threads = stn.value("Settings/threads", 0).toInt();
         m_rowHeight = stn.value("Settings/row_size").toInt();
         ui->switchViewMode->setCurrentIndex(stn.value("Settings/switch_view_mode", 0).toInt());
         ui->switchCutting->setCurrentIndex(stn.value("Settings/switch_cut_mode", 0).toInt());
@@ -1007,6 +1010,7 @@ void MainWindow::onSettings()
                            &m_multiInstances,
                            &m_showHdrFlag,
                            &m_timerInterval,
+                           &m_threads,
                            &m_theme,
                            &m_prefixName,
                            &m_suffixName,
@@ -1022,7 +1026,8 @@ void MainWindow::onSettings()
                            &m_subtitles_color,
                            &m_subtitles_background_color,
                            &m_subtitles_background_alpha,
-                           &m_subtitles_location);
+                           &m_subtitles_location
+                           );
     if (settings.exec() == Dialog::Accept) {
         m_pTimer->setInterval(m_timerInterval*1000);
         setTheme(m_theme);
@@ -1532,7 +1537,8 @@ void MainWindow::initEncoding()
                              QString(subtitles_color.name(QColor::HexArgb).replace("#", "")),
                              m_subtitles_background,
                              QString(subtitles_background_color.name(QColor::HexArgb).replace("#", "")),
-                             m_subtitles_location
+                             m_subtitles_location,
+                             m_threads
     );
 }
 

--- a/app/mainwindow.h
+++ b/app/mainwindow.h
@@ -212,7 +212,8 @@ private:
                 m_pos_cld,
                 m_timerInterval,
                 m_subtitles_background_alpha,
-                m_subtitles_location;
+                m_subtitles_location,
+                m_threads;
 
     QString     m_language,
                 m_output_folder,

--- a/app/message.cpp
+++ b/app/message.cpp
@@ -13,7 +13,7 @@
 #include "message.h"
 #include "ui_message.h"
 #include "helper.h"
-#include <QSound>
+#include <QSoundEffect>
 
 #define ELAPSED_TIME 25
 
@@ -102,7 +102,9 @@ void Message::setMessage()
 #if defined (Q_OS_WIN64)
         QSound::play("./cine-encoder.wav");
 #elif defined (Q_OS_UNIX)
-        QSound::play("/usr/share/sounds/cine-encoder.wav");
+        QSoundEffect se;
+        se.setSource(QUrl::fromLocalFile("/usr/share/sounds/cine-encoder.wav"));
+        se.play();
 #endif
         show_message();
     } else {

--- a/app/platform_unix/basewindow.cpp
+++ b/app/platform_unix/basewindow.cpp
@@ -102,8 +102,8 @@ void BaseWindow::showEvent(QShowEvent *event)
 
 void BaseWindow::mouseMoveEvent(QMouseEvent *event)
 {
-    const int x = event->x();
-    const int y = event->y();
+    const int x = event->position().x();
+    const int y = event->position().y();
     if (m_resizingCornerEdge == XUtils::CornerEdge::kInvalid && m_isResizable) {
         XUtils::UpdateCursorShape(this, x, y, this->contentsMargins(), BORDER);
     }
@@ -112,15 +112,15 @@ void BaseWindow::mouseMoveEvent(QMouseEvent *event)
 
 void BaseWindow::mousePressEvent(QMouseEvent *event)
 {
-    const int x = event->x();
-    const int y = event->y();
+    const int x = event->position().x();
+    const int y = event->position().y();
     if (event->button() == Qt::LeftButton && m_isResizable) {
         const XUtils::CornerEdge ce = XUtils::GetCornerEdge(this, x, y,
                                                             this->contentsMargins(),
                                                             BORDER);
         if (ce != XUtils::CornerEdge::kInvalid) {
             m_resizingCornerEdge = ce;
-            XUtils::SendButtonRelease(this, event->pos(), event->globalPos());
+            XUtils::SendButtonRelease(this, event->pos(), event->globalPosition().toPoint());
             XUtils::StartResizing(this, QCursor::pos(), ce);
         }
     }
@@ -165,7 +165,7 @@ bool BaseWindow::eventFilter(QObject *watched, QEvent *event)
         if ((event->type() == QEvent::MouseButtonPress)) {
             QMouseEvent* mouse_event = dynamic_cast<QMouseEvent*>(event);
             if (mouse_event->buttons() & Qt::LeftButton) {
-                XUtils::SendButtonRelease(this, mouse_event->pos(), mouse_event->globalPos());
+                XUtils::SendButtonRelease(this, mouse_event->pos(), mouse_event->globalPosition().toPoint());
                 XUtils::MoveWindow(this, Qt::LeftButton);
                 return true;
             }

--- a/app/platform_unix/xutil.cpp
+++ b/app/platform_unix/xutil.cpp
@@ -17,12 +17,13 @@
 
 #include "xutil.h"
 #include <QDebug>
+#include <QApplication>
 #include <QTimer>
 #include <QWidget>
-#include <QX11Info>
 #include <X11/Xatom.h>
-#include <X11/Xlib.h>
+//#include <X11/Xlib.h>
 #include <X11/extensions/shape.h>
+#include <qguiapplication_platform.h>
 
 QT_BEGIN_NAMESPACE
 
@@ -124,8 +125,11 @@ static XCursorType CornerEdge2XCursor(const CornerEdge &ce)
 
 void ChangeWindowMaximizedState(const QWidget *widget, int wm_state)
 {
-	const auto display = QX11Info::display();
-	const auto screen = QX11Info::appScreen();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 
 	XEvent xev;
 	memset(&xev, 0, sizeof(xev));
@@ -149,7 +153,7 @@ void ChangeWindowMaximizedState(const QWidget *widget, int wm_state)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   QX11Info::appRootWindow(screen),
+			   rootWindow,
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -182,8 +186,12 @@ CornerEdge GetCornerEdge(const QWidget *widget, int x, int y, const QMargins &ma
 
 void SendMoveResizeMessage(const QWidget *widget, Qt::MouseButton qbutton, int action)
 {
-	const auto display = QX11Info::display();
-	const auto screen = QX11Info::appScreen();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(connection);
+
 	int xbtn = qbutton == Qt::LeftButton ? Button1 :
 			   qbutton == Qt::RightButton ? Button3 :
 			   AnyButton;
@@ -203,10 +211,10 @@ void SendMoveResizeMessage(const QWidget *widget, Qt::MouseButton qbutton, int a
 	xev.xclient.data.l[2] = action;
 	xev.xclient.data.l[3] = xbtn;
 	xev.xclient.data.l[4] = 0;
-	XUngrabPointer(display, QX11Info::appTime());
+	XUngrabPointer(display, CurrentTime);
 
 	XSendEvent(display,
-			   QX11Info::appRootWindow(screen),
+			   rootWindow,
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -234,7 +242,11 @@ void MoveResizeWindow(const QWidget *widget, Qt::MouseButton qbutton, int x, int
 
 void ResetCursorShape(const QWidget *widget)
 {
-	const auto display = QX11Info::display();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 	const WId window_id = widget->winId();
 	XUndefineCursor(display, window_id);
 	XFlush(display);
@@ -242,7 +254,11 @@ void ResetCursorShape(const QWidget *widget)
 
 bool SetCursorShape(const QWidget *widget, int cursor_id)
 {
-	const auto display = QX11Info::display();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 	const WId window_id = widget->winId();
 	const Cursor cursor = XCreateFontCursor(display, cursor_id);
 	if (!cursor) {
@@ -257,8 +273,11 @@ bool SetCursorShape(const QWidget *widget, int cursor_id)
 void SendButtonRelease(const QWidget *widget,
                        const QPoint &pos, const QPoint &globalPos)
 {
-	const auto display = QX11Info::display();
-	const auto screen = QX11Info::appScreen();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(connection);
     Q_UNUSED(screen)
 
 	XEvent xevent;
@@ -279,8 +298,11 @@ void SendButtonRelease(const QWidget *widget,
 
 void ShowFullscreenWindow(const QWidget *widget, bool is_fullscreen)
 {
-	const auto display = QX11Info::display();
-	const auto screen = QX11Info::appScreen();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 
 	XEvent xev;
 	memset(&xev, 0, sizeof(xev));
@@ -302,7 +324,7 @@ void ShowFullscreenWindow(const QWidget *widget, bool is_fullscreen)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   QX11Info::appRootWindow(screen),
+			   rootWindow,
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev
@@ -317,8 +339,11 @@ void ShowMaximizedWindow(const QWidget *widget)
 
 void ShowMinimizedWindow(const QWidget *widget, bool minimized)
 {
-	const auto display = QX11Info::display();
-	const auto screen = QX11Info::appScreen();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 
 	XEvent xev;
 	memset(&xev, 0, sizeof(xev));
@@ -340,13 +365,13 @@ void ShowMinimizedWindow(const QWidget *widget, bool minimized)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   QX11Info::appRootWindow(screen),
+			   rootWindow,
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev
 			  );
 
-	XIconifyWindow(display, widget->winId(), screen);
+	XIconifyWindow(display, widget->winId(), qApp->screens().indexOf(screen));
 	XFlush(display);
 }
 
@@ -376,8 +401,11 @@ void SkipTaskbarPager(const QWidget *widget)
 {
 	Q_ASSERT(widget);
 
-	const auto display = QX11Info::display();
-	const auto screen = QX11Info::appScreen();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 
 	const auto wmStateAtom = XInternAtom(display, kAtomNameWmState, false);
 	const auto taskBarAtom = XInternAtom(display, kAtomNameWmSkipTaskbar, false);
@@ -398,7 +426,7 @@ void SkipTaskbarPager(const QWidget *widget)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   QX11Info::appRootWindow(screen),
+			   rootWindow,
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -409,8 +437,11 @@ void SetStayOnTop(const QWidget *widget, bool on)
 {
 	Q_ASSERT(widget);
 
-	const auto display = QX11Info::display();
-	const auto screen = QX11Info::appScreen();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 
 	const auto wmStateAtom = XInternAtom(display, kAtomNameWmState, false);
 	const auto stateAboveAtom = XInternAtom(display, kAtomNameWmStateAbove, false);
@@ -432,7 +463,7 @@ void SetStayOnTop(const QWidget *widget, bool on)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   QX11Info::appRootWindow(screen),
+			   rootWindow,
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -442,7 +473,11 @@ void SetStayOnTop(const QWidget *widget, bool on)
 void SetMouseTransparent(const QWidget *widget, bool on)
 {
 	Q_ASSERT(widget);
-	const auto display = QX11Info::display();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = widget->screen();
+    auto rootWindow = DefaultRootWindow(&connection);
 	XRectangle XRect;
 	XRect.x = 0;
 	XRect.y = 0;
@@ -470,7 +505,11 @@ void SetWindowExtents(const QWidget *widget, const QMargins &margins, const int 
 
 void PropagateSizeHints(const QWidget *w)
 {
-	const auto display = QX11Info::display();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = w->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 	XSizeHints *sh = XAllocSizeHints();
 	sh->flags = PPosition | PSize | PMinSize | PMaxSize | PResizeInc;
 	sh->x = w->x();
@@ -489,7 +528,11 @@ void PropagateSizeHints(const QWidget *w)
 
 void DisableResize(const QWidget *w)
 {
-	Display *display = QX11Info::display();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = w->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 	Atom mwmHintsProperty = XInternAtom(display, "_MOTIF_WM_HINTS", 0);
 	struct MwmHints *hints;
 	unsigned char *wm_data;
@@ -540,9 +583,12 @@ void DisableResize(const QWidget *w)
 
 void StartResizing(const QWidget *w, const QPoint &globalPoint, const CornerEdge &ce)
 {
-	const auto display = QX11Info::display();
 	const auto winId = w->winId();
-	const auto screen = QX11Info::appScreen();
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    const auto screen = w->screen();
+    auto rootWindow = DefaultRootWindow(connection);
 
 	XEvent xev;
 	const Atom netMoveResize = XInternAtom(display, "_NET_WM_MOVERESIZE", false);
@@ -557,10 +603,10 @@ void StartResizing(const QWidget *w, const QPoint &globalPoint, const CornerEdge
 	xev.xclient.data.l[2] = CornerEdge2WmGravity(ce);
 	xev.xclient.data.l[3] = Button1;
 	xev.xclient.data.l[4] = 1;
-	XUngrabPointer(display, QX11Info::appTime());
+	XUngrabPointer(display, CurrentTime);
 
 	XSendEvent(display,
-			   QX11Info::appRootWindow(screen),
+			   rootWindow,
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -574,6 +620,10 @@ void CancelMoveWindow(const QWidget *widget, Qt::MouseButton qbutton)
 
 void SetWindowExtents(uint wid, const QRect &windowRect, const QMargins &margins, const int resizeHandleSize)
 {
+    auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
+    const auto display = x11App->display();
+    const auto connection = x11App->connection();
+    auto rootWindow = DefaultRootWindow(&connection);
 	Atom frameExtents;
 	unsigned long value[4] = {
 		(unsigned long)(margins.left()),
@@ -581,12 +631,12 @@ void SetWindowExtents(uint wid, const QRect &windowRect, const QMargins &margins
 		(unsigned long)(margins.top()),
 		(unsigned long)(margins.bottom())
 	};
-	frameExtents = XInternAtom(QX11Info::display(), "_GTK_FRAME_EXTENTS", False);
+	frameExtents = XInternAtom(display, "_GTK_FRAME_EXTENTS", False);
 	if (frameExtents == None) {
 		qWarning() << "Failed to create atom with name DEEPIN_WINDOW_SHADOW";
 		return;
 	}
-	XChangeProperty(QX11Info::display(),
+	XChangeProperty(display,
 					wid,
 					frameExtents,
 					XA_CARDINAL,
@@ -604,7 +654,7 @@ void SetWindowExtents(uint wid, const QRect &windowRect, const QMargins &margins
 	contentXRect.y = 0;
 	contentXRect.width = tmp_rect.width() + resizeHandleSize * 2;
 	contentXRect.height = tmp_rect.height() + resizeHandleSize * 2;
-	XShapeCombineRectangles(QX11Info::display(),
+	XShapeCombineRectangles(display,
 							wid,
 							ShapeInput,
 							margins.left() - resizeHandleSize,

--- a/app/platform_unix/xutil.cpp
+++ b/app/platform_unix/xutil.cpp
@@ -24,6 +24,7 @@
 //#include <X11/Xlib.h>
 #include <X11/extensions/shape.h>
 #include <qguiapplication_platform.h>
+#include <QtGui/private/qtx11extras_p.h>
 
 QT_BEGIN_NAMESPACE
 
@@ -125,12 +126,15 @@ static XCursorType CornerEdge2XCursor(const CornerEdge &ce)
 
 void ChangeWindowMaximizedState(const QWidget *widget, int wm_state)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(connection);
-
+    */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	XEvent xev;
 	memset(&xev, 0, sizeof(xev));
 	const Atom net_wm_state = XInternAtom(display, kAtomNameWmState, false);
@@ -153,7 +157,7 @@ void ChangeWindowMaximizedState(const QWidget *widget, int wm_state)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   rootWindow,
+               QX11Info::appRootWindow(screen),
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -186,13 +190,17 @@ CornerEdge GetCornerEdge(const QWidget *widget, int x, int y, const QMargins &ma
 
 void SendMoveResizeMessage(const QWidget *widget, Qt::MouseButton qbutton, int action)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(connection);
+    */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 
-	int xbtn = qbutton == Qt::LeftButton ? Button1 :
+    int xbtn = qbutton == Qt::LeftButton ? Button1 :
 			   qbutton == Qt::RightButton ? Button3 :
 			   AnyButton;
 
@@ -214,7 +222,7 @@ void SendMoveResizeMessage(const QWidget *widget, Qt::MouseButton qbutton, int a
 	XUngrabPointer(display, CurrentTime);
 
 	XSendEvent(display,
-			   rootWindow,
+               QX11Info::appRootWindow(screen),
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -242,11 +250,15 @@ void MoveResizeWindow(const QWidget *widget, Qt::MouseButton qbutton, int x, int
 
 void ResetCursorShape(const QWidget *widget)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(connection);
+     */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	const WId window_id = widget->winId();
 	XUndefineCursor(display, window_id);
 	XFlush(display);
@@ -254,11 +266,15 @@ void ResetCursorShape(const QWidget *widget)
 
 bool SetCursorShape(const QWidget *widget, int cursor_id)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(connection);
+     */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	const WId window_id = widget->winId();
 	const Cursor cursor = XCreateFontCursor(display, cursor_id);
 	if (!cursor) {
@@ -273,11 +289,15 @@ bool SetCursorShape(const QWidget *widget, int cursor_id)
 void SendButtonRelease(const QWidget *widget,
                        const QPoint &pos, const QPoint &globalPos)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(connection);
+    */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
     Q_UNUSED(screen)
 
 	XEvent xevent;
@@ -298,11 +318,15 @@ void SendButtonRelease(const QWidget *widget,
 
 void ShowFullscreenWindow(const QWidget *widget, bool is_fullscreen)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(connection);
+    */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 
 	XEvent xev;
 	memset(&xev, 0, sizeof(xev));
@@ -324,7 +348,7 @@ void ShowFullscreenWindow(const QWidget *widget, bool is_fullscreen)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   rootWindow,
+               QX11Info::appRootWindow(screen),
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev
@@ -339,12 +363,16 @@ void ShowMaximizedWindow(const QWidget *widget)
 
 void ShowMinimizedWindow(const QWidget *widget, bool minimized)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(connection);
+    */
 
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	XEvent xev;
 	memset(&xev, 0, sizeof(xev));
 	const Atom net_wm_state = XInternAtom(display, kAtomNameWmState, false);
@@ -365,13 +393,13 @@ void ShowMinimizedWindow(const QWidget *widget, bool minimized)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   rootWindow,
+               QX11Info::appRootWindow(screen),
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev
 			  );
 
-	XIconifyWindow(display, widget->winId(), qApp->screens().indexOf(screen));
+	XIconifyWindow(display, widget->winId(), screen);
 	XFlush(display);
 }
 
@@ -401,12 +429,16 @@ void SkipTaskbarPager(const QWidget *widget)
 {
 	Q_ASSERT(widget);
 
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(connection);
+    */
 
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	const auto wmStateAtom = XInternAtom(display, kAtomNameWmState, false);
 	const auto taskBarAtom = XInternAtom(display, kAtomNameWmSkipTaskbar, false);
 	const auto noPagerAtom = XInternAtom(display, kAtomNameWmSkipPager, false);
@@ -426,7 +458,7 @@ void SkipTaskbarPager(const QWidget *widget)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   rootWindow,
+               QX11Info::appRootWindow(screen),
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -437,12 +469,15 @@ void SetStayOnTop(const QWidget *widget, bool on)
 {
 	Q_ASSERT(widget);
 
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(connection);
-
+    */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	const auto wmStateAtom = XInternAtom(display, kAtomNameWmState, false);
 	const auto stateAboveAtom = XInternAtom(display, kAtomNameWmStateAbove, false);
 	const auto stateStaysOnTopAtom = XInternAtom(display,
@@ -463,7 +498,7 @@ void SetStayOnTop(const QWidget *widget, bool on)
 	xev.xclient.data.l[3] = 1;
 
 	XSendEvent(display,
-			   rootWindow,
+               QX11Info::appRootWindow(screen),
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -473,11 +508,15 @@ void SetStayOnTop(const QWidget *widget, bool on)
 void SetMouseTransparent(const QWidget *widget, bool on)
 {
 	Q_ASSERT(widget);
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = widget->screen();
     auto rootWindow = DefaultRootWindow(&connection);
+    */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	XRectangle XRect;
 	XRect.x = 0;
 	XRect.y = 0;
@@ -505,11 +544,16 @@ void SetWindowExtents(const QWidget *widget, const QMargins &margins, const int 
 
 void PropagateSizeHints(const QWidget *w)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = w->screen();
     auto rootWindow = DefaultRootWindow(connection);
+    */
+
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	XSizeHints *sh = XAllocSizeHints();
 	sh->flags = PPosition | PSize | PMinSize | PMaxSize | PResizeInc;
 	sh->x = w->x();
@@ -528,11 +572,15 @@ void PropagateSizeHints(const QWidget *w)
 
 void DisableResize(const QWidget *w)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = w->screen();
     auto rootWindow = DefaultRootWindow(connection);
+    */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	Atom mwmHintsProperty = XInternAtom(display, "_MOTIF_WM_HINTS", 0);
 	struct MwmHints *hints;
 	unsigned char *wm_data;
@@ -584,11 +632,16 @@ void DisableResize(const QWidget *w)
 void StartResizing(const QWidget *w, const QPoint &globalPoint, const CornerEdge &ce)
 {
 	const auto winId = w->winId();
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
     const auto screen = w->screen();
     auto rootWindow = DefaultRootWindow(connection);
+    */
+
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 
 	XEvent xev;
 	const Atom netMoveResize = XInternAtom(display, "_NET_WM_MOVERESIZE", false);
@@ -606,7 +659,7 @@ void StartResizing(const QWidget *w, const QPoint &globalPoint, const CornerEdge
 	XUngrabPointer(display, CurrentTime);
 
 	XSendEvent(display,
-			   rootWindow,
+               QX11Info::appRootWindow(screen),
 			   false,
 			   SubstructureRedirectMask | SubstructureNotifyMask,
 			   &xev);
@@ -620,10 +673,13 @@ void CancelMoveWindow(const QWidget *widget, Qt::MouseButton qbutton)
 
 void SetWindowExtents(uint wid, const QRect &windowRect, const QMargins &margins, const int resizeHandleSize)
 {
+    /*
     auto *x11App = qApp->nativeInterface<QNativeInterface::QX11Application>();
     const auto display = x11App->display();
     const auto connection = x11App->connection();
-    auto rootWindow = DefaultRootWindow(&connection);
+     */
+    const auto display = QX11Info::display();
+    const auto screen = QX11Info::appScreen();
 	Atom frameExtents;
 	unsigned long value[4] = {
 		(unsigned long)(margins.left()),

--- a/app/settings.cpp
+++ b/app/settings.cpp
@@ -250,8 +250,8 @@ void Settings::setParameters(QString    *pOutputFolder,
     ui->comboBoxPrefixType->setView(comboboxPrefixTypeListView);
     ui->comboBoxSuffixType->setView(comboboxSuffixTypeListView);
 
-    QRegExpValidator *prefixValidator = new QRegExpValidator(QRegExp("^[^\\\\/:*?\"<>|+%!@]*$"), ui->lineEditPrefix);
-    QRegExpValidator *suffixValidator = new QRegExpValidator(QRegExp("^[^\\\\/:*?\"<>|+%!@]*$"), ui->lineEditSuffix);
+    QRegularExpressionValidator *prefixValidator = new QRegularExpressionValidator(QRegularExpression("^[^\\\\/:*?\"<>|+%!@]*$"), ui->lineEditPrefix);
+    QRegularExpressionValidator *suffixValidator = new QRegularExpressionValidator(QRegularExpression("^[^\\\\/:*?\"<>|+%!@]*$"), ui->lineEditSuffix);
     ui->lineEditPrefix->setValidator(prefixValidator);
     ui->lineEditSuffix->setValidator(suffixValidator);
 }

--- a/app/settings.cpp
+++ b/app/settings.cpp
@@ -72,9 +72,27 @@ Settings::Settings(QWidget *parent):
         &Settings::onComboBoxPrefixType_indexChanged, &Settings::onComboBoxSuffixType_indexChanged,
         &Settings::onComboBoxFont_indexChanged, &Settings::onComboBoxSubtitlesFont_indexChanged
     };
-    for (int i = 0; i < 5; i++)
-        connect(boxes[i], static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+    // Release build, this crashes out and i gets to 12.... No idea.
+    /*
+    for (int i = 0; i < 5; i++) {
+        connect(boxes[i], static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
                 this, boxes_methods[i]);
+    }
+     */
+    // Do it manually to prevent the failure.
+    int j = 0;
+    connect(boxes[j], static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this, boxes_methods[j]);
+    j++;
+    connect(boxes[j], static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this, boxes_methods[j]);
+    j++;
+    connect(boxes[j], static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this, boxes_methods[j]);
+    j++;
+    connect(boxes[j], static_cast<void (QComboBox::*)(int)>(&QComboBox::currentIndexChanged),
+            this, boxes_methods[j]);
+
 
     // On close
     connect(this, &Settings::destroyed, this, [this]() {

--- a/app/settings.cpp
+++ b/app/settings.cpp
@@ -277,13 +277,18 @@ void Settings::onButtonApply()
     *m_pSubtitlesFontSize = arrFontSize[subtitles_font_size_index];
 
     /*===================== Theme =================*/
-    *m_pTheme = ui->comboBox_theme->currentIndex();
+    if (*m_pTheme != ui->comboBox_theme->currentIndex()) {
+        *m_pTheme = ui->comboBox_theme->currentIndex();
+        restart_needed = true;
+    }
 
     /*===================== Lang ==================*/
     const int lang_index = ui->comboBox_lang->currentIndex();
     QString arrLang[4] = {"en", "zh", "de", "ru"};
-    *m_pLanguage = arrLang[lang_index];
-
+    if (*m_pLanguage != arrLang[lang_index]) {
+        *m_pLanguage = arrLang[lang_index];
+        restart_needed = true;
+    }
     /*==================== Paths ==================*/
     *m_pTempFolder = ui->lineEdit_tempPath->text();
     *m_pOutputFolder = ui->lineEdit_outPath->text();
@@ -343,6 +348,7 @@ void Settings::onButtonApply()
 
 void Settings::onButtonReset()
 {
+    restart_needed = true;
     ui->lineEdit_tempPath->clear();
     ui->lineEdit_outPath->clear();
     ui->checkBox_showHDR->setChecked(false);

--- a/app/settings.cpp
+++ b/app/settings.cpp
@@ -96,6 +96,7 @@ void Settings::setParameters(QString    *pOutputFolder,
                              bool       *pMultiInstances,
                              bool       *pShowHdrFlag,
                              int        *pTimerInterval,
+                             int        *pThreads,
                              int        *pTheme,
                              QString    *pPrefixName,
                              QString    *pSuffixName,
@@ -122,6 +123,7 @@ void Settings::setParameters(QString    *pOutputFolder,
     m_pProtectFlag = pProtectFlag;
     m_pMultiInstances = pMultiInstances;
     m_pTimerInterval = pTimerInterval;
+    m_pThreads = pThreads;
     m_pTheme = pTheme;
     m_pPrefixName = pPrefixName;
     m_pSuffixName = pSuffixName;
@@ -146,6 +148,7 @@ void Settings::setParameters(QString    *pOutputFolder,
     ui->lineEdit_tempPath->setText(*m_pTempFolder);
     ui->lineEdit_outPath->setText(*m_pOutputFolder);
     ui->spinBox_protectionTimer->setValue(*m_pTimerInterval);
+    ui->spinBox_threads->setValue(*m_pThreads);
 
     if (*m_pShowHdrFlag) {
         ui->checkBox_showHDR->setChecked(true);
@@ -294,6 +297,7 @@ void Settings::onButtonApply()
     *m_pShowHdrFlag = (stts_hdr_info == 2) ? true : false;
 
     /*================ Protection ================*/
+    *m_pThreads = ui->spinBox_threads->value();
     *m_pTimerInterval = ui->spinBox_protectionTimer->value();
     int stts_protect = ui->checkBox_protection->checkState();
     *m_pProtectFlag = (stts_protect == 2) ? true : false;
@@ -346,6 +350,7 @@ void Settings::onButtonReset()
     ui->checkBox_protection->setChecked(false);
     ui->checkBox_allowDuplicates->setChecked(false);
     ui->spinBox_protectionTimer->setEnabled(false);
+    ui->spinBox_threads->setValue(0);
     ui->comboBox_theme->setCurrentIndex(3);
     ui->comboBox_lang->setCurrentIndex(0);
     ui->comboBoxPrefixType->setCurrentIndex(0);

--- a/app/settings.h
+++ b/app/settings.h
@@ -44,6 +44,7 @@ public:
                        bool       *pMultiInstances,
                        bool       *pShowHdrFlag,
                        int        *pTimerInterval,
+                       int        *pThreads,
                        int        *pTheme,
                        QString    *pPrefixName,
                        QString    *pSuffixName,
@@ -98,6 +99,7 @@ private:
             *m_pPrefxType,
             *m_pSuffixType,
             *m_pTimerInterval,
+            *m_pThreads,
             *m_pTheme,
             *m_pSubtitlesBackgroundAlpha,
             *m_pSubtitlesLocation;

--- a/app/settings.h
+++ b/app/settings.h
@@ -37,7 +37,11 @@ class Settings : public BaseWindow
 public:
     explicit Settings(QWidget *parent = nullptr);
     ~Settings();
-
+    // Below is set to true if a setting is changed in Apply that requires an application restart.
+    // Reset will always prompt for a restart.
+    // There is no explicit set to false - once this is set to true, the prompt should be shown
+    // with successive visits to the settings dialog.
+    bool restart_needed;
     void setParameters(QString    *pOutputFolder,
                        QString    *pTempFolder,
                        bool       *pProtectFlag,

--- a/app/settings.ui
+++ b/app/settings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>589</width>
-    <height>654</height>
+    <width>610</width>
+    <height>711</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -1334,7 +1334,106 @@
                         <property name="rightMargin">
                          <number>0</number>
                         </property>
-                        <item row="2" column="2">
+                        <item row="5" column="4">
+                         <spacer name="horizontalSpacer_4">
+                          <property name="orientation">
+                           <enum>Qt::Horizontal</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>40</width>
+                            <height>20</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                        <item row="3" column="2">
+                         <widget class="QCheckBox" name="checkBox_protection">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>246</width>
+                            <height>0</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>246</width>
+                            <height>16777215</height>
+                           </size>
+                          </property>
+                          <property name="styleSheet">
+                           <string notr="true"/>
+                          </property>
+                          <property name="text">
+                           <string>Enable overheating protection (for 25 sec)</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="4" column="2">
+                         <spacer name="verticalSpacer_14">
+                          <property name="orientation">
+                           <enum>Qt::Vertical</enum>
+                          </property>
+                          <property name="sizeType">
+                           <enum>QSizePolicy::Fixed</enum>
+                          </property>
+                          <property name="sizeHint" stdset="0">
+                           <size>
+                            <width>20</width>
+                            <height>18</height>
+                           </size>
+                          </property>
+                         </spacer>
+                        </item>
+                        <item row="1" column="1">
+                         <widget class="QLabel" name="label_threads">
+                          <property name="text">
+                           <string>Threads</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="5" column="1" alignment="Qt::AlignRight">
+                         <widget class="QLabel" name="label_protectionTimer">
+                          <property name="enabled">
+                           <bool>false</bool>
+                          </property>
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>      Every</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="2">
+                         <widget class="QSpinBox" name="spinBox_threads">
+                          <property name="enabled">
+                           <bool>true</bool>
+                          </property>
+                          <property name="minimumSize">
+                           <size>
+                            <width>30</width>
+                            <height>24</height>
+                           </size>
+                          </property>
+                          <property name="maximumSize">
+                           <size>
+                            <width>90</width>
+                            <height>30</height>
+                           </size>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="5" column="2">
                          <widget class="QSpinBox" name="spinBox_protectionTimer">
                           <property name="enabled">
                            <bool>false</bool>
@@ -1380,77 +1479,7 @@
                           </property>
                          </widget>
                         </item>
-                        <item row="1" column="2">
-                         <spacer name="verticalSpacer_14">
-                          <property name="orientation">
-                           <enum>Qt::Vertical</enum>
-                          </property>
-                          <property name="sizeType">
-                           <enum>QSizePolicy::Fixed</enum>
-                          </property>
-                          <property name="sizeHint" stdset="0">
-                           <size>
-                            <width>20</width>
-                            <height>18</height>
-                           </size>
-                          </property>
-                         </spacer>
-                        </item>
-                        <item row="2" column="1" alignment="Qt::AlignRight">
-                         <widget class="QLabel" name="label_7">
-                          <property name="enabled">
-                           <bool>false</bool>
-                          </property>
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="text">
-                           <string>      Every</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="3" alignment="Qt::AlignLeft">
-                         <widget class="QLabel" name="label_6">
-                          <property name="enabled">
-                           <bool>false</bool>
-                          </property>
-                          <property name="text">
-                           <string>sec</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="2" colspan="2">
-                         <widget class="QCheckBox" name="checkBox_protection">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="minimumSize">
-                           <size>
-                            <width>246</width>
-                            <height>0</height>
-                           </size>
-                          </property>
-                          <property name="maximumSize">
-                           <size>
-                            <width>246</width>
-                            <height>16777215</height>
-                           </size>
-                          </property>
-                          <property name="styleSheet">
-                           <string notr="true"/>
-                          </property>
-                          <property name="text">
-                           <string>Enable overheating protection (for 25 sec)</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="2" column="0">
+                        <item row="5" column="0">
                          <spacer name="horizontalSpacer_6">
                           <property name="orientation">
                            <enum>Qt::Horizontal</enum>
@@ -1466,15 +1495,25 @@
                           </property>
                          </spacer>
                         </item>
-                        <item row="2" column="4">
-                         <spacer name="horizontalSpacer_4">
+                        <item row="5" column="3" alignment="Qt::AlignLeft">
+                         <widget class="QLabel" name="label_protectionTimer2">
+                          <property name="enabled">
+                           <bool>false</bool>
+                          </property>
+                          <property name="text">
+                           <string>sec</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="2" column="2">
+                         <spacer name="verticalSpacer_20">
                           <property name="orientation">
-                           <enum>Qt::Horizontal</enum>
+                           <enum>Qt::Vertical</enum>
                           </property>
                           <property name="sizeHint" stdset="0">
                            <size>
-                            <width>40</width>
-                            <height>20</height>
+                            <width>20</width>
+                            <height>18</height>
                            </size>
                           </property>
                          </spacer>


### PR DESCRIPTION
Allow the restart prompt to be displayed only when settings requiring a tool restart have been changed. I've picked out the theme and language settings in this PR, but there may be others. The aim is to avoid having the restart prompt shown for cases like subtitles, where the changes are effective immediately.